### PR TITLE
Migrate sample To-Do app to testmuai.com

### DIFF
--- a/Resources/Common.robot
+++ b/Resources/Common.robot
@@ -25,7 +25,7 @@ Open test browser
     # Create Selenium options based on browser
     ${options}=    Evaluate    sys.modules['selenium.webdriver'].${BROWSER.capitalize()}Options()    sys, selenium.webdriver
     Call Method    ${options}    set_capability    LT:Options    ${LT_OPTIONS}
-    Open Browser   https://lambdatest.github.io/sample-todo-app/    ${BROWSER}    remote_url=${REMOTE_URL}    options=${options}
+    Open Browser   https://www.testmuai.com/selenium-playground/todo-app/    ${BROWSER}    remote_url=${REMOTE_URL}    options=${options}
 
 Close test browser
     Run Keyword If    '${REMOTE_URL}' != ''

--- a/Tests/sample_test.robot
+++ b/Tests/sample_test.robot
@@ -19,5 +19,5 @@ Example of connecting to Lambdatest via Robot Framework
 		
 	Input text  id:sampletodotext  Yey Let's add it to list
 	Click button  id:addbutton
-	${response}    Get Text    xpath=/html/body/div/div/div/ul/li[6]/span
+	${response}    Get Text    xpath=//input[@name='li6']/following-sibling::span
 	Should Be Equal As Strings    ${response}    Yey Let's add it to list


### PR DESCRIPTION
### What
The LambdaTest sample To-Do app at `https://lambdatest.github.io/sample-todo-app/` has been **deprecated** and replaced by `https://www.testmuai.com/selenium-playground/todo-app/`. This PR points the tests at the new app.

### Why it's more than a URL swap
The new app is a **React** port of the old **AngularJS** app. Stable hooks are preserved — `#sampletodotext`, `#addbutton`, checkbox `name="li1".."liN"`, and added items still get sequential `li6/li7/...` names. But a few things changed, so the affected selectors/assertions were updated and **validated against the live new app**:
- Page `<title>` is now `Selenium Grid Online | Run Selenium Test On Cloud` (was `Modern To-Do App | LambdaTest`).
- Angular `ng-model`/`ng-repeat` attributes are gone → replaced with id/name/class selectors.
- `ul.list-unstyled` class and absolute XPaths like `/html/body/div/div/div/ul/li[N]/span` no longer match the new DOM → replaced with robust relative locators (e.g. `//input[@name='li6']/following-sibling::span`).

### Changes in this repo
```diff
diff --git a/Resources/Common.robot b/Resources/Common.robot
index 32253cb..2e0bebd 100644
--- a/Resources/Common.robot
+++ b/Resources/Common.robot
@@ -25,7 +25,7 @@ Open test browser
     # Create Selenium options based on browser
     ${options}=    Evaluate    sys.modules['selenium.webdriver'].${BROWSER.capitalize()}Options()    sys, selenium.webdriver
     Call Method    ${options}    set_capability    LT:Options    ${LT_OPTIONS}
-    Open Browser   https://lambdatest.github.io/sample-todo-app/    ${BROWSER}    remote_url=${REMOTE_URL}    options=${options}
+    Open Browser   https://www.testmuai.com/selenium-playground/todo-app/    ${BROWSER}    remote_url=${REMOTE_URL}    options=${options}
 
 Close test browser
     Run Keyword If    '${REMOTE_URL}' != ''
diff --git a/Tests/sample_test.robot b/Tests/sample_test.robot
index d773519..606537b 100644
--- a/Tests/sample_test.robot
+++ b/Tests/sample_test.robot
@@ -19,5 +19,5 @@ Example of connecting to Lambdatest via Robot Framework
 		
 	Input text  id:sampletodotext  Yey Let's add it to list
 	Click button  id:addbutton
-	${response}    Get Text    xpath=/html/body/div/div/div/ul/li[6]/span
+	${response}    Get Text    xpath=//input[@name='li6']/following-sibling::span
 	Should Be Equal As Strings    ${response}    Yey Let's add it to list
```

> Note: the new page's `<title>` looks like it may be inheriting the generic selenium-playground title. If it's later corrected upstream, the title-based assertions here may need revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
